### PR TITLE
Also check types when linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
     "packages/*"
   ],
   "scripts": {
-    "lint": "eslint '**/*.{js,ts,tsx}' --max-warnings=0",
+    "check-types": "tsc -p tsconfig.eslint.json --noemit",
+    "eslint": "eslint '**/*.{js,ts,tsx}' --max-warnings=0",
+    "lint": "yarn eslint && yarn check-types",
     "test": "jest --coverage"
   },
   "devDependencies": {


### PR DESCRIPTION
eslint does not check typescript type errors, so this needs to be added